### PR TITLE
Release 1.0.0 (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,37 +9,7 @@ Entries for releases prior to 1.0.0 are reconstructed from the git history.
 
 ## [Unreleased]
 
-### Added
-
-- Zensical-based documentation site under `website/kslides/` with
-  dark mode as the default and curated navigation. Code examples
-  live in `kslides-core/src/test/kotlin/website/` and are pulled
-  into the markdown via `pymdownx.snippets` so the docs and the
-  compilable sources stay in sync
-  ([#33](https://github.com/kslides/kslides/pull/33)).
-- `.github/workflows/docs.yml` — GitHub Actions docs workflow that
-  generates Dokka HTML, runs the Zensical build, and publishes both
-  the site and `api-docs/` to GitHub Pages.
-- `Makefile`: `clean-docs`, `kdocs`, `site`, `serve` targets for the
-  documentation site.
-- `.gitignore` entries for Python and Zensical output.
-
-### Changed
-
-- Gradle wrapper upgraded from 9.4.1 to 9.5.0.
-- `kotlin-css` bumped to `2026.4.14`.
-- `kslides-core` promotes the `srcref` dependency from
-  `implementation` to `api`.
-
-### Removed
-
-- Duplicate Makefile targets.
-- Unused plugin entries from `gradle/libs.versions.toml`
-  (`dokka`, `kotlin-jvm`, `maven-publish`, and the `pambrose-*`
-  convention plugins) — these are applied via `buildSrc` precompiled
-  scripts and don't need version-catalog entries.
-
-## [1.0.0] — 2026-04-XX
+## [1.0.0] — 2026-04-29
 
 First stable release. Ground-up modernization of the build, the
 chart-embedding integration, and the test/CI story
@@ -68,6 +38,20 @@ chart-embedding integration, and the test/CI story
   `UtilFunctionsTest`, `ConfigPropertyTest`, `RecordIframeContentTest`.
 - `kslides-letsplot` test suite: `LetsPlotTest` (renderer unit tests)
   and `LetsPlotDslTest` (full DSL → filesystem integration).
+- Zensical-based documentation site under `website/kslides/` with
+  dark mode as the default and curated navigation. Code examples
+  live in `kslides-core/src/test/kotlin/website/` and are pulled
+  into the markdown via `pymdownx.snippets` so the docs and the
+  compilable sources stay in sync
+  ([#33](https://github.com/kslides/kslides/pull/33)).
+- `.github/workflows/docs.yml` — GitHub Actions docs workflow that
+  generates Dokka HTML, runs the Zensical build, and publishes both
+  the site and `api-docs/` to GitHub Pages.
+- `Makefile`: `clean-docs`, `kdocs`, `site`, `serve` targets for the
+  documentation site.
+- `.gitignore` entries for Python and Zensical output.
+- Example slides published to GitHub Pages
+  ([#35](https://github.com/kslides/kslides/pull/35)).
 
 ### Changed
 
@@ -104,8 +88,11 @@ chart-embedding integration, and the test/CI story
 - `UtilsTest` and `PresentationTest` converted to
   `StringSpec() { init { ... } }` style.
 - Build scripts migrated from Groovy DSL to Kotlin DSL
-  (`*.gradle.kts`). Gradle wrapper bumped to 9.4.1.
+  (`*.gradle.kts`). Gradle wrapper bumped to 9.5.0.
 - Kotlin bumped to 2.3.x; Ktor to 3.4.x; Kotest to 6.x.
+- `kotlin-css` bumped to `2026.4.14`.
+- `kslides-core` promotes the `srcref` dependency from
+  `implementation` to `api`.
 - README, `llms.txt`, and `CLAUDE.md` rewritten.
 
 ### Removed
@@ -118,6 +105,11 @@ chart-embedding integration, and the test/CI story
 - Commented-out `KSlidesConfig.plotlyUrl` field.
 - Legacy CI configs (`.travis.yml`, `jitpack.yml`).
 - Stale `docs/plotly/` generated output; replaced by `docs/letsPlot/`.
+- Duplicate Makefile targets.
+- Unused plugin entries from `gradle/libs.versions.toml`
+  (`dokka`, `kotlin-jvm`, `maven-publish`, and the `pambrose-*`
+  convention plugins) — these are applied via `buildSrc` precompiled
+  scripts and don't need version-catalog entries.
 
 ### Fixed
 
@@ -669,7 +661,7 @@ chart-embedding integration, and the test/CI story
   per-slide / per-presentation overrides.
 
 [Unreleased]: https://github.com/kslides/kslides/compare/1.0.0...HEAD
-[1.0.0]: https://github.com/kslides/kslides/compare/0.24.0...1.0.0
+[1.0.0]: https://github.com/kslides/kslides/releases/tag/1.0.0
 [0.24.0]: https://github.com/kslides/kslides/releases/tag/0.24.0
 [0.23.0]: https://github.com/kslides/kslides/releases/tag/0.23.0
 [0.22.0]: https://github.com/kslides/kslides/releases/tag/0.22.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ For testing, use `kslidesTest{}` instead of `kslides{}` — it suppresses filesy
 ## Tech Stack
 
 - Kotlin 2.3.21, JVM 17 toolchain
-- Gradle Kotlin DSL (`*.gradle.kts`), wrapper 9.4.1
+- Gradle Kotlin DSL (`*.gradle.kts`), wrapper 9.5.0
 - Ktor 3.4.3 (server + client)
 - kotlinx.html / kotlinx.css for HTML/CSS DSL
 - Lets-Plot Kotlin 4.13.0 for the `letsPlot{}` DSL (matched JS runtime v4.9.0, configurable via `KSlidesConfig.letsPlotJsVersion`)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ or the Kotlin [HTML DSL](https://github.com/Kotlin/kotlinx.html/wiki/Getting-sta
 
 [This presentation](kslides-examples/src/main/kotlin/Slides.kt) is served statically from
 [Netlify](https://kslides.netlify.app)
-and [GitHub Pages](https://kslides.github.io/kslides/).
-It is also running dynamically on [Heroku](https://kslides-repo.herokuapp.com).
+and [GitHub Pages](https://kslides.github.io/kslides/docs/index.html).
+kslides content can also run dynamically on Heroku.
 
 ## Getting Started
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,36 +6,7 @@ structured, category-grouped log.
 
 ---
 
-## Unreleased
-
-### Build / tooling
-
-- Gradle wrapper upgraded from 9.4.1 to 9.5.0.
-- `kotlin-css` bumped to `2026.4.14`.
-- Removed duplicate Makefile targets and unused plugin entries from
-  `gradle/libs.versions.toml` (dokka, kotlin-jvm, maven-publish, and
-  the `pambrose-*` convention plugins are now applied via `buildSrc`
-  precompiled scripts and don't need version-catalog entries).
-
-### Documentation
-
-- New [Zensical](https://zensical.org/) documentation site under
-  `website/kslides/`, with dark mode as the default and a curated
-  navigation (Getting started, Slides, Configuration, Output, Styling,
-  Include, Extensions, Markdown reference, KDocs). Code examples live
-  in `kslides-core/src/test/kotlin/website/` and are pulled into the
-  markdown via `pymdownx.snippets`, so the docs and the compilable
-  sources stay in sync.
-- New `.github/workflows/docs.yml` builds the Dokka HTML output and
-  the Zensical site, then publishes both (site + `api-docs/`) to
-  GitHub Pages.
-- Drive-by: `kslides-core` promotes `srcref` from `implementation` to
-  `api`; `Makefile` gains `clean-docs` / `site` targets; `.gitignore`
-  covers Python + Zensical output.
-
----
-
-## 1.0.0 — 2026-04-XX
+## 1.0.0 — 2026-04-29
 
 First stable release. The project graduates from `0.x` after a
 ground-up modernization of the build, the chart-embedding
@@ -108,9 +79,14 @@ to work unchanged.
 - Shared build logic centralized in `buildSrc/` precompiled-script
   convention plugins (`kslides.kotlin-module`,
   `kslides.published-module`).
-- Gradle wrapper bumped to 9.4.1.
+- Gradle wrapper bumped to 9.5.0.
 - Kotlin 2.3.20+, Ktor 3.4.x, Kotest 6.x.
+- `kotlin-css` bumped to `2026.4.14`.
 - Dependency versions centralized in `gradle/libs.versions.toml`.
+- Removed duplicate Makefile targets and unused plugin entries from
+  `gradle/libs.versions.toml` (dokka, kotlin-jvm, maven-publish, and
+  the `pambrose-*` convention plugins are now applied via `buildSrc`
+  precompiled scripts and don't need version-catalog entries).
 - New GitHub Actions CI (`.github/workflows/ci.yml`) runs
   `./gradlew build` on every PR and every push to `master`; failing
   runs upload a `test-reports` artifact.
@@ -119,6 +95,25 @@ to work unchanged.
   plugin. Group ID is now `com.kslides` (Maven Central), replacing
   the old JitPack `com.github.kslides`.
 - Dokka 2.x configured for HTML API docs.
+
+#### Documentation
+
+- New [Zensical](https://zensical.org/) documentation site under
+  `website/kslides/`, with dark mode as the default and a curated
+  navigation (Getting started, Slides, Configuration, Output, Styling,
+  Include, Extensions, Markdown reference, KDocs). Code examples live
+  in `kslides-core/src/test/kotlin/website/` and are pulled into the
+  markdown via `pymdownx.snippets`, so the docs and the compilable
+  sources stay in sync
+  ([#33](https://github.com/kslides/kslides/pull/33)).
+- New `.github/workflows/docs.yml` builds the Dokka HTML output and
+  the Zensical site, then publishes both (site + `api-docs/`) to
+  GitHub Pages.
+- Example slides published to GitHub Pages
+  ([#35](https://github.com/kslides/kslides/pull/35)).
+- `kslides-core` promotes `srcref` from `implementation` to `api`;
+  `Makefile` gains `clean-docs` / `site` targets; `.gitignore`
+  covers Python + Zensical output.
 
 #### Test coverage
 

--- a/kslides-core/src/main/kotlin/com/kslides/KSlides.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/KSlides.kt
@@ -25,6 +25,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.css.CssBuilder
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Marks receiver types that participate in the kslides DSL so that Kotlin's scope-control can
@@ -113,7 +114,9 @@ fun kslides(block: KSlides.() -> Unit) =
 fun kslidesTest(block: KSlides.() -> Unit) =
   kslides {
     block()
+    val userOutputBlock = outputConfigBlock
     output {
+      userOutputBlock()
       enableFileSystem = false
       enableHttp = false
     }
@@ -139,9 +142,9 @@ class KSlides {
   internal var outputConfigBlock: OutputConfig.() -> Unit = {}
   internal var presentationBlocks = mutableListOf<Presentation.() -> Unit>()
   internal val presentationMap = mutableMapOf<String, Presentation>()
-  internal val staticIframeContent = mutableMapOf<String, String>()
-  internal val dynamicIframeContent = mutableMapOf<String, () -> String>()
-  internal val staticKrokiContent = mutableMapOf<String, ByteArray>()
+  internal val staticIframeContent = ConcurrentHashMap<String, String>()
+  internal val dynamicIframeContent = ConcurrentHashMap<String, () -> String>()
+  internal val staticKrokiContent = ConcurrentHashMap<String, ByteArray>()
   internal var slideCount = 1
 
   internal val presentations get() = presentationMap.values

--- a/kslides-core/src/main/kotlin/com/kslides/Utils.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/Utils.kt
@@ -136,26 +136,29 @@ fun include(
   trimIndent: Boolean = true,
   indentToken: String = INDENT_TOKEN,
   escapeHtml: Boolean = true,
-) = runCatching {
-  if (src.isUrl()) {
-    URL(src)
-      .readText()
-      .lines()
-      .fromTo(beginToken, endToken, exclusive)
-      .toLineRanges(linePattern)
-      .fixIndents(indentToken, trimIndent, escapeHtml)
-  } else {
-    // Do not let queries wander outside of repo
-    if (src.contains("../")) throw IllegalArgumentException("Illegal filename: $src")
-    File("${System.getProperty("user.dir")}/$src")
-      .readLines()
-      .fromTo(beginToken, endToken, exclusive)
-      .toLineRanges(linePattern)
-      .fixIndents(indentToken, trimIndent, escapeHtml)
+): String {
+  // Do not let queries wander outside of repo — validated up front so the contract documented
+  // in the KDoc (`@throws IllegalArgumentException`) is honored regardless of the read path.
+  if (!src.isUrl() && src.contains("../")) throw IllegalArgumentException("Illegal filename: $src")
+  return runCatching {
+    if (src.isUrl()) {
+      URL(src)
+        .readText()
+        .lines()
+        .fromTo(beginToken, endToken, exclusive)
+        .toLineRanges(linePattern)
+        .fixIndents(indentToken, trimIndent, escapeHtml)
+    } else {
+      File("${System.getProperty("user.dir")}/$src")
+        .readLines()
+        .fromTo(beginToken, endToken, exclusive)
+        .toLineRanges(linePattern)
+        .fixIndents(indentToken, trimIndent, escapeHtml)
+    }
+  }.getOrElse { e ->
+    KSlides.logger.warn(e) { "Unable to read ${if (src.isUrl()) "url" else "file"} $src" }
+    ""
   }
-}.getOrElse { e ->
-  KSlides.logger.warn(e) { "Unable to read ${if (src.isUrl()) "url" else "file"} $src" }
-  ""
 }
 
 /**

--- a/kslides-core/src/main/kotlin/com/kslides/config/PresentationConfig.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/config/PresentationConfig.kt
@@ -421,7 +421,7 @@ class PresentationConfig : AbstractConfig() {
     // Doesn't appear when href is assigned an empty string
     topRightHref = ""
     topRightTarget = HrefTarget.SELF
-    topLeftTitle = ""
+    topRightTitle = ""
     topRightSvg = ""
     topRightSvgSrc = ""
     topRightSvgClass = "top-right-svg"

--- a/llms.txt
+++ b/llms.txt
@@ -111,8 +111,8 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("com.kslides:kslides-core:VERSION")
-    // Optional: implementation("com.kslides:kslides-letsplot:VERSION")
+    implementation("com.kslides:kslides-core:1.0.0")
+    // Optional: implementation("com.kslides:kslides-letsplot:1.0.0")
 }
 ```
 


### PR DESCRIPTION
## Summary

- Fold the `Unreleased` `CHANGELOG.md` / `RELEASE_NOTES.md` entries into the `1.0.0` section, dated `2026-04-29`. Correct the Gradle wrapper version (9.4.1 → 9.5.0) in `CLAUDE.md` and in the 1.0.0 release notes. Pin the `llms.txt` dependency snippet to `1.0.0`.
- Fix `PresentationConfig.assignDefaults` so `topRightTitle` is initialized (was overwriting `topLeftTitle`), so reads of `topRightTitle` no longer throw.
- `kslidesTest` now replays the user-supplied `output{}` block before forcing `enableFileSystem`/`enableHttp` to false, so user settings like `outputDir` are preserved in tests.
- `include()` validates `"../"` before `runCatching` so the documented `IllegalArgumentException` actually propagates instead of being silently demoted to an empty string.
- Switch the `KSlides` iframe/Kroki content maps to `ConcurrentHashMap` so Ktor handler reads are safe alongside DSL-time writes.

## Test plan

- [ ] `./gradlew build` is green locally and on CI.
- [ ] `./gradlew :kslides-core:test` passes.
- [ ] `./gradlew :kslides-letsplot:test` passes.
- [ ] Spot-check a presentation that uses `topRightTitle` to confirm the default no longer throws.
- [ ] Spot-check a `kslidesTest { output { outputDir = ... } }` test to confirm `outputDir` is honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)