### PR TITLE
Replace DslSlide.private_section hack with a SECTION context parameter

### DIFF
--- a/buildSrc/src/main/kotlin/kslides.kotlin-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kslides.kotlin-module.gradle.kts
@@ -10,6 +10,11 @@ val libs = the<VersionCatalogsExtension>().named("libs")
 
 kotlin {
     jvmToolchain(libs.findVersion("jvm").get().requiredVersion.toInt())
+    compilerOptions {
+        // Enable context parameters (experimental in Kotlin 2.4) so DSL extension functions can
+        // receive the enclosing kotlinx.html SECTION implicitly instead of via a mutable field.
+        freeCompilerArgs.add("-Xcontext-parameters")
+    }
 }
 
 // Detekt 2.0 is alpha; report findings without failing the build. Override per-project

--- a/kslides-core/src/main/kotlin/com/kslides/DiagramDsl.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/DiagramDsl.kt
@@ -12,10 +12,10 @@ import io.ktor.client.plugins.onDownload
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.http.ContentType
 import io.ktor.http.ContentType.Application
 import io.ktor.http.contentType
 import kotlinx.coroutines.runBlocking
+import kotlinx.html.SECTION
 import kotlinx.html.div
 import kotlinx.html.img
 import kotlinx.html.style
@@ -48,8 +48,11 @@ class DiagramDescription : DiagramConfig() {
  *   `"graphviz"`, `"erd"`. See [Kroki's supported types](https://kroki.io/#support).
  * @param diagramBlock populates a [DiagramDescription] with the diagram source and optional
  *   [DiagramConfig] overrides (size, style, output format, Kroki options).
- * @throws IllegalStateException if called outside a [DslSlide] `content{}` block.
+ *
+ * The enclosing `<section>` is supplied via the [SECTION] context parameter, so calling this
+ * outside a [DslSlide] `content{}` block is a compile-time error.
  */
+context(section: SECTION)
 fun DslSlide.diagram(
   diagramType: String,
   diagramBlock: DiagramDescription.() -> Unit,
@@ -80,7 +83,7 @@ fun DslSlide.diagram(
     fetchKrokiContent(filename, configMap)
   }
 
-  private_section?.div(classes.nullIfBlank()) {
+  section.div(classes.nullIfBlank()) {
     img {
       src = krokiFilename(filename)
       mergedConfig.width.also { if (it.isNotBlank()) width = it }
@@ -88,7 +91,7 @@ fun DslSlide.diagram(
       mergedConfig.style.also { if (it.isNotBlank()) style = it }
       mergedConfig.title.also { if (it.isNotBlank()) title = it }
     }
-  } ?: error("diagram() must be called from within a content{} block")
+  }
 }
 
 private fun DslSlide.fetchKrokiContent(

--- a/kslides-core/src/main/kotlin/com/kslides/PlaygroundDsl.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/PlaygroundDsl.kt
@@ -3,6 +3,7 @@ package com.kslides
 import com.kslides.Playground.playgroundContent
 import com.kslides.config.PlaygroundConfig
 import com.kslides.slide.DslSlide
+import kotlinx.html.SECTION
 import kotlinx.html.iframe
 import kotlinx.html.style
 import kotlinx.html.title
@@ -21,8 +22,11 @@ import kotlinx.html.title
  *   JUnit helpers, etc.).
  * @param configBlock optional [PlaygroundConfig] overrides (iframe size, editor theme, target
  *   platform, auto-complete, etc.). Merged with global and presentation-level defaults.
- * @throws IllegalStateException if called outside a [DslSlide] `content{}` block.
+ *
+ * The enclosing `<section>` is supplied via the [SECTION] context parameter, so calling this
+ * outside a [DslSlide] `content{}` block is a compile-time error.
  */
+context(section: SECTION)
 fun DslSlide.playground(
   srcName: String,
   vararg otherSrcs: String = emptyArray(),
@@ -50,11 +54,11 @@ fun DslSlide.playground(
     playgroundContent(presentation.kslides, mergedConfig, combinedCss, srcName, otherSrcs.toList())
   }
 
-  private_section?.iframe {
+  section.iframe {
     src = playgroundFilename(filename)
     mergedConfig.width.also { if (it.isNotBlank()) width = it }
     mergedConfig.height.also { if (it.isNotBlank()) height = it }
     mergedConfig.style.also { if (it.isNotBlank()) style = it }
     mergedConfig.title.also { if (it.isNotBlank()) title = it }
-  } ?: error("playground() must be called from within a content{} block")
+  }
 }

--- a/kslides-core/src/main/kotlin/com/kslides/Presentation.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/Presentation.kt
@@ -667,7 +667,6 @@ private fun SECTION.processMarkdown(
 private fun DIV.processDsl(s: DslSlide) {
   section(s.classes.nullIfBlank()) {
     s.processSlide(this)
-    s.private_section = this // TODO This is a hack that will go away when context receivers work
     s.private_dslBlock(this)
     require(s.private_dslAssigned) { "dslSlide missing content{} block" }
   }.also { rawHtml("\n") }

--- a/kslides-core/src/main/kotlin/com/kslides/slide/DslSlide.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/slide/DslSlide.kt
@@ -27,9 +27,6 @@ interface DslSlide {
   /** The [Presentation] that owns this slide. */
   val presentation: Presentation
 
-  /** Implementation detail — do not use. */
-  var private_section: SECTION? // TODO This is a hack that will go away when context receivers work
-
   /** Implementation detail — unique slide id used to generate iframe filenames. */
   val private_slideId: Int
 
@@ -121,7 +118,6 @@ class HorizontalDslSlide(
   content: SlideArgs,
 ) : HorizontalSlide(presentation, content),
   DslSlide {
-  override var private_section: SECTION? = null
   override var private_dslBlock: SECTION.() -> Unit = { }
   override var private_iframeCount = 1
   override var private_useHttp: Boolean = false
@@ -152,7 +148,6 @@ class VerticalDslSlide(
   content: SlideArgs,
 ) : VerticalSlide(presentation, content),
   DslSlide {
-  override var private_section: SECTION? = null
   override var private_dslBlock: SECTION.() -> Unit = { }
   override var private_iframeCount = 1
   override var private_useHttp: Boolean = false

--- a/kslides-letsplot/src/main/kotlin/com/kslides/LetsPlotDsl.kt
+++ b/kslides-letsplot/src/main/kotlin/com/kslides/LetsPlotDsl.kt
@@ -4,6 +4,7 @@ import com.kslides.LetsPlot.letsPlotContent
 import com.kslides.LetsPlot.scriptUrlForVersion
 import com.kslides.config.LetsPlotIframeConfig
 import com.kslides.slide.DslSlide
+import kotlinx.html.SECTION
 import kotlinx.html.iframe
 import kotlinx.html.style
 import kotlinx.html.title
@@ -26,8 +27,11 @@ import org.jetbrains.letsPlot.commons.geometry.DoubleVector
  * @param iframeConfig size/style overrides for the enclosing iframe. Merged with global and
  *   presentation defaults.
  * @param block lambda returning the [Figure] to render.
- * @throws IllegalStateException if called outside a [DslSlide] `content{}` block.
+ *
+ * The enclosing `<section>` is supplied via the [SECTION] context parameter, so calling this
+ * outside a [DslSlide] `content{}` block is a compile-time error.
  */
+context(section: SECTION)
 fun DslSlide.letsPlot(
   dimensions: Dimensions? = null,
   iframeConfig: LetsPlotIframeConfig = LetsPlotIframeConfig(),
@@ -49,11 +53,11 @@ fun DslSlide.letsPlot(
     letsPlotContent(block(), scriptUrl, plotSize)
   }
 
-  private_section?.iframe {
+  section.iframe {
     src = letsPlotFilename(filename)
     mergedConfig.width.also { if (it.isNotBlank()) this.width = it }
     mergedConfig.height.also { if (it.isNotBlank()) this.height = it }
     mergedConfig.style.also { if (it.isNotBlank()) this.style = it }
     mergedConfig.title.also { if (it.isNotBlank()) this.title = it }
-  } ?: error("letsPlot() must be called from within a content{} block")
+  }
 }


### PR DESCRIPTION
## Summary

Eliminates the `var private_section: SECTION?` field on `DslSlide` (long marked `// TODO This is a hack that will go away when context receivers work`) using Kotlin **context parameters**.

The field existed only to ferry the live `<section>` builder from the renderer to the `playground` / `diagram` / `letsPlot` extension DSLs, which are declared on `DslSlide` rather than on `SECTION`. The renderer wrote the field right before invoking the user's `content { }` block, and each extension null-checked it at runtime (`?: error("... must be called from within a content{} block")`).

Since `content { }`'s receiver is already `SECTION`, a `context(section: SECTION)` on each extension lets the compiler supply it implicitly.

## Changes

- **buildSrc** — enable `-Xcontext-parameters` in the shared `kslides.kotlin-module` convention plugin (experimental in Kotlin 2.4).
- **DslSlide.kt** — remove the `private_section` interface member and both `override` initializers.
- **Presentation.kt** — drop the `s.private_section = this` write in `processDsl`.
- **PlaygroundDsl.kt / DiagramDsl.kt / LetsPlotDsl.kt** — add `context(section: SECTION)`, use `section.iframe`/`section.div`, and drop the runtime null-check (now a compile-time guarantee). KDoc updated accordingly.

## Behavior note

The "called outside a content{} block" failure is now a **compile-time** error rather than a runtime one. The only edge case affected is nesting a call inside another kotlinx.html builder (e.g. `content { div { playground(...) } }`), which `@DslMarker` shadowing would now reject at compile time — no code in the repo does this, and these calls always emitted to the section regardless of nesting anyway.

## Verification

`./gradlew :kslides-core:build :kslides-letsplot:build :kslides-examples:build` — BUILD SUCCESSFUL, including all tests, lint, and the example deck which exercises every `playground`/`diagram`/`letsPlot` call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)