### PR TITLE
Fix GA id leak, include() silent failures, and 6 more review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ For testing, use `kslidesTest{}` instead of `kslides{}` — it suppresses filesy
 - Gradle Kotlin DSL (`*.gradle.kts`), wrapper 9.5.0
 - Ktor 3.5.0 (server + client)
 - kotlinx.html / kotlinx.css for HTML/CSS DSL
-- Lets-Plot Kotlin 4.14.0 for the `letsPlot{}` DSL (matched JS runtime v4.9.0, configurable via `KSlidesConfig.letsPlotJsVersion`)
+- Lets-Plot Kotlin 4.14.0 for the `letsPlot{}` DSL (matched JS runtime v4.10.1 — the `lets-plot-common` core version it resolves to — configurable via `KSlidesConfig.letsPlotJsVersion`)
 - Kotlinter for linting (ktlint-based) and Detekt 2.0.0-alpha.3 for static analysis (`dev.detekt`)
 - reveal.js assets live at the repo root in `docs/revealjs/` (single source of truth, committed for GitHub Pages). `kslides-core/build.gradle.kts` grafts them onto the published JAR's classpath at `revealjs/**` via `processResources` so the Ktor static handler can serve them at runtime — there is no checked-in `kslides-core/src/main/resources/revealjs/` directory.
 - All versions — including the JVM toolchain (`jvm`) and the Gradle wrapper distribution (`gradle-wrapper`) — are centralized in `gradle/libs.versions.toml`. The convention plugin reads `jvm` via `VersionCatalogsExtension`, and the `Makefile`'s `upgrade-wrapper` target reads `gradle-wrapper` from the same file.

--- a/kslides-core/src/main/kotlin/com/kslides/InternalUtils.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/InternalUtils.kt
@@ -148,9 +148,10 @@ internal object InternalUtils {
   ): List<String> {
     val beginIndex =
       if (beginToken.isNotBlank()) {
-        // Do not match calling token in the same file
-        val unquotedBegin = Regex(beginToken)
-        val quotedBegin = Regex("$beginToken\"")
+        // Do not match calling token in the same file. Tokens are documented as plain substrings,
+        // so escape them — a metacharacter (e.g. "items[0]") must not be compiled as a regex.
+        val unquotedBegin = Regex(Regex.escape(beginToken))
+        val quotedBegin = Regex(Regex.escape(beginToken) + "\"")
         (
           asSequence()
             .mapIndexed { i, s -> i to s }
@@ -164,9 +165,10 @@ internal object InternalUtils {
 
     val endIndex =
       if (endToken.isNotBlank()) {
-        // Do not match calling token in the same file
-        val unquotedEnd = Regex(endToken)
-        val quotedEnd = Regex("$endToken\"")
+        // Do not match calling token in the same file. Tokens are documented as plain substrings,
+        // so escape them — a metacharacter (e.g. "items[0]") must not be compiled as a regex.
+        val unquotedEnd = Regex(Regex.escape(endToken))
+        val quotedEnd = Regex(Regex.escape(endToken) + "\"")
         (
           reversed()
             .asSequence()
@@ -228,7 +230,9 @@ internal object InternalUtils {
       }
   }
 
-  internal fun mkdir(name: String) = File(name).run { if (!exists()) mkdir() else false }
+  // mkdirs() (not mkdir()) so nested output paths — e.g. playground/letsPlot/kroki subdirs under a
+  // multi-segment outputDir — are created in full rather than silently no-oping on a missing parent.
+  internal fun mkdir(name: String) = File(name).run { exists() || mkdirs() }
 
   private val httpRegex = Regex("\\s*http[s]?://.*")
 

--- a/kslides-core/src/main/kotlin/com/kslides/KSlides.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/KSlides.kt
@@ -241,8 +241,8 @@ class KSlides {
       val outputDir = config.outputDir
       val rootPrefix = config.staticRootDir.ensureSuffix("/")
 
-      // Create directory if missing
-      File(outputDir).mkdir()
+      // Create directory (including any missing parents) if absent
+      File(outputDir).also { if (!it.exists() && !it.mkdirs()) logger.warn { "Unable to create output directory: $outputDir" } }
 
       config.kslides.presentationMap
         .forEach { (key, p) ->
@@ -260,8 +260,8 @@ class KSlides {
                 val pathElems = "$outputDir/$key".split("/").filter { it.isNotBlank() }
                 val path = pathElems.joinToString("/")
                 val dotDot = List(pathElems.size - 1) { "../" }.joinToString("")
-                // Create directory if missing
-                File(path).mkdir()
+                // Create directory (including any missing parents) if absent
+                File(path).also { if (!it.exists() && !it.mkdirs()) logger.warn { "Unable to create directory: $path" } }
                 File("$path/index.html") to "$dotDot$rootPrefix"
               }
             }

--- a/kslides-core/src/main/kotlin/com/kslides/Page.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/Page.kt
@@ -35,6 +35,11 @@ internal object Page {
     useHttp: Boolean = true,
     srcPrefix: String = "/",
   ): String {
+    // Not dead code: vertical-stack child slides are (re)constructed during render via the
+    // verticalSlides{} block, and each one pulls its id from this shared counter (Slide.private_slideId).
+    // Resetting per render keeps those ids — and therefore the per-slide iframe filenames
+    // (slide-<id>-<n>) — stable across the repeated renders an HTTP server performs. NOTE: this makes
+    // generatePage mutate shared KSlides state, so concurrent renders are not yet thread-safe.
     p.kslides.slideCount = 0
     val htmldoc =
       document {
@@ -128,7 +133,7 @@ internal object Page {
       rawHtml("\n")
       script {
         async = true
-        src = "https://www.googletagmanager.com/gtag/js?id=G-Z6YBNZS12K"
+        src = "https://www.googletagmanager.com/gtag/js?id=${config.gaPropertyId}"
       }
       rawHtml("\n\n\t\t")
       script {

--- a/kslides-core/src/main/kotlin/com/kslides/Utils.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/Utils.kt
@@ -13,6 +13,7 @@ import kotlinx.html.CODE
 import kotlinx.html.HTMLTag
 import kotlinx.html.unsafe
 import java.io.File
+import java.io.IOException
 import java.net.URL
 
 /** Internal utility holder — not part of the public API. */
@@ -124,8 +125,11 @@ fun githubRawUrl(
  *   surrounding Markdown/HTML; set to `""` in code contexts.
  * @param escapeHtml HTML-escape the returned content; disable for [kotlinx.html.CODE] blocks
  *   that already own their escaping.
- * @return the resolved content, or an empty string if reading fails (a warning is logged).
- * @throws IllegalArgumentException if [src] is a local path containing `"../"`.
+ * @return the resolved content, or an empty string if the file/URL cannot be read (an I/O failure,
+ *   missing file, or failed HTTP fetch — a warning is logged). Authoring errors such as an absent
+ *   [beginToken]/[endToken] or a malformed [linePattern] are not swallowed; they propagate.
+ * @throws IllegalArgumentException if [src] is a local path containing `"../"`, or if a
+ *   [beginToken]/[endToken] is not found, or if [linePattern] is malformed.
  */
 fun include(
   src: String,
@@ -140,25 +144,26 @@ fun include(
   // Do not let queries wander outside of repo — validated up front so the contract documented
   // in the KDoc (`@throws IllegalArgumentException`) is honored regardless of the read path.
   if (!src.isUrl() && src.contains("../")) throw IllegalArgumentException("Illegal filename: $src")
-  return runCatching {
-    if (src.isUrl()) {
-      URL(src)
-        .readText()
-        .lines()
-        .fromTo(beginToken, endToken, exclusive)
-        .toLineRanges(linePattern)
-        .fixIndents(indentToken, trimIndent, escapeHtml)
-    } else {
-      File("${System.getProperty("user.dir")}/$src")
-        .readLines()
-        .fromTo(beginToken, endToken, exclusive)
-        .toLineRanges(linePattern)
-        .fixIndents(indentToken, trimIndent, escapeHtml)
+
+  // Only I/O failures (missing file, unreachable URL, 404) are recoverable — they warn and yield an
+  // empty string. Authoring errors (a begin/end token that is absent, a malformed linePattern) are
+  // allowed to propagate so a mistake fails the build loudly rather than silently rendering a blank
+  // slide. See `include()`'s `@return`/`@throws` contract.
+  val lines =
+    try {
+      if (src.isUrl())
+        URL(src).readText().lines()
+      else
+        File("${System.getProperty("user.dir")}/$src").readLines()
+    } catch (e: IOException) {
+      KSlides.logger.warn(e) { "Unable to read ${if (src.isUrl()) "url" else "file"} $src" }
+      return ""
     }
-  }.getOrElse { e ->
-    KSlides.logger.warn(e) { "Unable to read ${if (src.isUrl()) "url" else "file"} $src" }
-    ""
-  }
+
+  return lines
+    .fromTo(beginToken, endToken, exclusive)
+    .toLineRanges(linePattern)
+    .fixIndents(indentToken, trimIndent, escapeHtml)
 }
 
 /**

--- a/kslides-core/src/main/kotlin/com/kslides/config/KSlidesConfig.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/config/KSlidesConfig.kt
@@ -47,12 +47,14 @@ class KSlidesConfig {
   var playgroundUrl = "https://unpkg.com/kotlin-playground@1"
 
   /**
-   * Lets-Plot JS runtime version loaded by generated `letsPlot{}` iframes. Must be compatible
-   * with the `lets-plot-kotlin-jvm` artifact on the classpath (e.g. `lets-plot-kotlin-jvm:4.13.0`
-   * → Lets-Plot core `4.9.0`). Overriding here avoids a library release when a compatible JS
-   * runtime is published upstream.
+   * Lets-Plot JS runtime version loaded by generated `letsPlot{}` iframes. Must match the
+   * `lets-plot-common` core version pulled in transitively by the `lets-plot-kotlin-jvm` artifact
+   * on the classpath (e.g. `lets-plot-kotlin-jvm:4.14.0` → Lets-Plot core `4.10.1`). Keep this in
+   * sync whenever the `letsplot` version in `gradle/libs.versions.toml` is bumped; the `ConfigsTest`
+   * "KSlidesConfig pins letsPlotJsVersion to the lets-plot core version" case pins the expected value.
+   * Overriding here avoids a library release when a compatible JS runtime is published upstream.
    */
-  var letsPlotJsVersion = "4.9.0"
+  var letsPlotJsVersion = "4.10.1"
 
   /** Kroki server URL used by [com.kslides.diagram] to render diagrams. */
   var krokiUrl = "https://kroki.io"

--- a/kslides-core/src/main/kotlin/com/kslides/slide/Slide.kt
+++ b/kslides-core/src/main/kotlin/com/kslides/slide/Slide.kt
@@ -101,10 +101,11 @@ abstract class Slide(
     if (style.isNotBlank())
       section.style = style
 
+    // hidden and uncounted both map to the single-valued data-visibility attribute; hidden is the
+    // strictly stronger flag, so it wins when both are set rather than being silently overwritten.
     if (hidden)
       section.attributes["data-visibility"] = "hidden"
-
-    if (uncounted)
+    else if (uncounted)
       section.attributes["data-visibility"] = "uncounted"
 
     if (autoAnimate)

--- a/kslides-core/src/test/kotlin/com/kslides/ConfigsTest.kt
+++ b/kslides-core/src/test/kotlin/com/kslides/ConfigsTest.kt
@@ -75,6 +75,13 @@ class ConfigsTest : StringSpec() {
       KSlidesConfig().letsPlotJsVersion.shouldNotBeBlank()
     }
 
+    "KSlidesConfig pins letsPlotJsVersion to the lets-plot core version" {
+      // The generated letsPlot{} iframes load this JS runtime; it must match the lets-plot-common
+      // core version pulled in transitively by lets-plot-kotlin-jvm (see gradle/libs.versions.toml,
+      // `letsplot = "4.14.0"` -> lets-plot-common 4.10.1). Bump both together.
+      KSlidesConfig().letsPlotJsVersion shouldBe "4.10.1"
+    }
+
     "KSlidesConfig default URLs are reasonable" {
       val config = KSlidesConfig()
       config.playgroundUrl shouldBe "https://unpkg.com/kotlin-playground@1"

--- a/kslides-core/src/test/kotlin/com/kslides/IncludeTest.kt
+++ b/kslides-core/src/test/kotlin/com/kslides/IncludeTest.kt
@@ -1,0 +1,80 @@
+package com.kslides
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+/**
+ * Exercises the public [include] function directly — its `../` traversal guard, the
+ * recoverable-vs-propagated failure contract, and the begin/end-token + line-pattern slicing.
+ * Local fixtures are created under the process working directory (`user.dir`) because that is the
+ * root [include] resolves relative paths against.
+ */
+class IncludeTest : StringSpec() {
+  init {
+    val workDir = File(System.getProperty("user.dir"))
+
+    fun withTempFile(
+      content: String,
+      block: (relName: String) -> Unit,
+    ) {
+      val file = File.createTempFile("kslides-include", ".kt", workDir)
+      try {
+        file.writeText(content)
+        block(file.name)
+      } finally {
+        file.delete()
+      }
+    }
+
+    "include() rejects local paths that escape the working directory" {
+      shouldThrowExactly<IllegalArgumentException> { include("../secret.txt") }
+      shouldThrowExactly<IllegalArgumentException> { include("a/../../etc/passwd") }
+    }
+
+    "include() does not apply the ../ guard to URLs" {
+      // isUrl() short-circuits the local-path traversal guard; an unreachable URL just yields an
+      // empty string via the recoverable I/O path, so no IllegalArgumentException is thrown.
+      shouldNotThrow<IllegalArgumentException> { include("https://kslides.invalid/../nope.kt") }
+    }
+
+    "include() returns an empty string when a local file is missing (recoverable I/O failure)" {
+      include("this-file-does-not-exist-9f3a2b.kt") shouldBe ""
+    }
+
+    "include() returns the full file contents by default" {
+      withTempFile("line1\nline2\nline3") { name ->
+        include(name, trimIndent = false, indentToken = "", escapeHtml = false) shouldBe "line1\nline2\nline3"
+      }
+    }
+
+    "include() honors a line pattern" {
+      withTempFile("a\nb\nc\nd") { name ->
+        include(name, linePattern = "2-3", trimIndent = false, indentToken = "", escapeHtml = false) shouldBe "b\nc"
+      }
+    }
+
+    "include() slices between begin and end tokens" {
+      withTempFile("pre\n// begin\nkept1\nkept2\n// end\npost") { name ->
+        include(
+          name,
+          beginToken = "// begin",
+          endToken = "// end",
+          trimIndent = false,
+          indentToken = "",
+          escapeHtml = false,
+        ) shouldBe "kept1\nkept2"
+      }
+    }
+
+    "include() propagates a missing begin token rather than silently returning an empty slide" {
+      withTempFile("a\nb\nc") { name ->
+        shouldThrowExactly<IllegalArgumentException> {
+          include(name, beginToken = "NOT-PRESENT")
+        }
+      }
+    }
+  }
+}

--- a/kslides-core/src/test/kotlin/com/kslides/PresentationTest.kt
+++ b/kslides-core/src/test/kotlin/com/kslides/PresentationTest.kt
@@ -4,6 +4,8 @@ import com.kslides.Page.generatePage
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 
 class PresentationTest : StringSpec() {
   init {
@@ -256,6 +258,84 @@ class PresentationTest : StringSpec() {
           }
         }
       }
+    }
+
+    "Google Analytics loader uses the configured property id, not a hardcoded one" {
+      val kslides =
+        kslidesTest {
+          presentation {
+            presentationConfig { gaPropertyId = "G-TESTID123" }
+            dslSlide { content { } }
+          }
+        }
+
+      val html = generatePage(kslides.presentation("/"))
+      html shouldContain "googletagmanager.com/gtag/js?id=G-TESTID123"
+      html shouldContain "gtag('config', 'G-TESTID123')"
+      // The maintainer's id must never leak into a consumer's generated deck.
+      html shouldNotContain "G-Z6YBNZS12K"
+    }
+
+    "data-visibility: hidden wins when both hidden and uncounted are set" {
+      val kslides =
+        kslidesTest {
+          presentation {
+            dslSlide {
+              hidden = true
+              uncounted = true
+              content { }
+            }
+          }
+        }
+
+      val html = generatePage(kslides.presentation("/"))
+      html shouldContain """data-visibility="hidden""""
+      html shouldNotContain """data-visibility="uncounted""""
+    }
+
+    "data-visibility: hidden-only emits hidden" {
+      val kslides =
+        kslidesTest {
+          presentation {
+            dslSlide {
+              hidden = true
+              content { }
+            }
+          }
+        }
+      generatePage(kslides.presentation("/")) shouldContain """data-visibility="hidden""""
+    }
+
+    "data-visibility: uncounted-only emits uncounted" {
+      val kslides =
+        kslidesTest {
+          presentation {
+            dslSlide {
+              uncounted = true
+              content { }
+            }
+          }
+        }
+      generatePage(kslides.presentation("/")) shouldContain """data-visibility="uncounted""""
+    }
+
+    "generatePage is idempotent across repeated renders, including vertical stacks" {
+      val kslides =
+        kslidesTest {
+          presentation {
+            dslSlide { content { } }
+            verticalSlides {
+              dslSlide { content { } }
+              dslSlide { content { } }
+            }
+          }
+        }
+      val p = kslides.presentation("/")
+
+      // Vertical-stack children are reconstructed on each render and draw ids from a shared counter
+      // that generatePage resets; rendering must therefore be a pure function of the built deck.
+      generatePage(p, false) shouldBe generatePage(p, false)
+      generatePage(p, true) shouldBe generatePage(p, true)
     }
   }
 }

--- a/kslides-core/src/test/kotlin/com/kslides/UtilsTest.kt
+++ b/kslides-core/src/test/kotlin/com/kslides/UtilsTest.kt
@@ -8,6 +8,7 @@ import com.kslides.InternalUtils.toIntList
 import com.kslides.InternalUtils.toLineRanges
 import com.kslides.InternalUtils.trimIndentWithInclude
 import com.kslides.config.PresentationConfig
+import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -329,6 +330,32 @@ val y = 1              // NO TAB
         it[0] shouldContain "1"
         it[1] shouldContain "3"
         it[2] shouldContain "5"
+      }
+    }
+
+    "fromTo treats begin/end tokens as literal substrings, not regex patterns" {
+      // Regression: tokens containing regex metacharacters must match literally and must never
+      // throw PatternSyntaxException (e.g. "items[0]", "foo(x)").
+      listOf("before", "tag items[0]", "kept", "end foo(x)", "after")
+        .fromTo(beginToken = "items[0]", endToken = "foo(x)") shouldBe listOf("kept")
+
+      // A literal token absent from the text reports "not found" rather than matching via regex
+      // semantics — a raw regex `a.c` would have matched "abc".
+      shouldThrowExactly<IllegalArgumentException> {
+        listOf("abc", "body").fromTo(beginToken = "a.c")
+      }
+    }
+
+    "mkdir creates nested directories" {
+      val base = java.nio.file.Files
+        .createTempDirectory("kslides-mkdir")
+        .toFile()
+      try {
+        val nested = java.io.File(base, "a/b/c").path
+        InternalUtils.mkdir(nested) shouldBe true
+        java.io.File(nested).isDirectory shouldBe true
+      } finally {
+        base.deleteRecursively()
       }
     }
 

--- a/kslides-letsplot/src/test/kotlin/com/kslides/LetsPlotTest.kt
+++ b/kslides-letsplot/src/test/kotlin/com/kslides/LetsPlotTest.kt
@@ -3,6 +3,7 @@ package com.kslides
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import org.jetbrains.letsPlot.commons.geometry.DoubleVector
 import org.jetbrains.letsPlot.geom.geomPoint
 import org.jetbrains.letsPlot.letsPlot
@@ -56,6 +57,16 @@ class LetsPlotTest : StringSpec() {
       val url = LetsPlot.scriptUrlForVersion("4.9.0")
       url.shouldContain("4.9.0")
       url.shouldContain("lets-plot")
+    }
+
+    "the default letsPlotJsVersion resolves to a real CDN URL (not a dev/localhost build)" {
+      val version = com.kslides.config
+        .KSlidesConfig()
+        .letsPlotJsVersion
+      val url = LetsPlot.scriptUrlForVersion(version)
+      url.shouldContain(version)
+      url.shouldContain("cdn.jsdelivr.net")
+      url.shouldNotContain("127.0.0.1")
     }
   }
 }


### PR DESCRIPTION
## What

Implements the 8 highest-leverage findings from a code-review pass over `kslides-core` and `kslides-letsplot`. Each fix ships with tests; the full `clean build` (tests + Kotlinter + Detekt) is green.

| # | Fix | File(s) |
|---|-----|---------|
| 1 | **GA id leak** — the gtag.js loader hardcoded the maintainer's `G-Z6YBNZS12K` while only the config call used the consumer's id; the loader `src` now uses `config.gaPropertyId` | `Page.kt` |
| 2 | **`include()` silent failures** — narrowed the catch to `IOException` so missing files/404s still recover to `""`, but missing tokens / malformed `linePattern` now fail loudly instead of shipping a blank slide | `Utils.kt` |
| 3 | **`include()` tests** — the central public API was untested; added `IncludeTest` (guard, URL guard-skip, line pattern, token slice, recover-empty, fail-loud) | `IncludeTest.kt` |
| 4 | **`mkdir()` → `mkdirs()`** — single-level `mkdir` silently no-ops on a missing parent then throws a confusing `FileNotFoundException`; now creates nested paths and logs failure | `InternalUtils.kt`, `KSlides.kt` |
| 5 | **`hidden`/`uncounted` collision** — both wrote the single-valued `data-visibility` via independent `if`s, so `uncounted` silently overwrote `hidden`; now mutually exclusive with `hidden` winning | `Slide.kt` |
| 6 | **Lets-Plot JS version** — default `4.9.0` was stale vs. the catalog's `lets-plot-kotlin-jvm:4.14.0` (resolves to `lets-plot-common 4.10.1`); bumped default + corrected KDoc/CLAUDE.md, added a pin test | `KSlidesConfig.kt`, `CLAUDE.md` |
| 7 | **Render shared-state docs + idempotency test** — see note below | `Page.kt` |
| 8 | **`fromTo` raw-regex tokens** — begin/end tokens were compiled as regex, so a metacharacter token (`items[0]`) could throw `PatternSyntaxException`/mis-match; now `Regex.escape`'d to match literally | `InternalUtils.kt` |

## Notes for the reviewer

**#2 is a behavior change worth a release note.** A deck that previously rendered a *blank slide* from a typo'd `include` token will now *fail the build*. That is the intended improvement (fail loud, not silent). Verified safe for the example deck: all 9 `include` sites resolve their files, every begin/end token exists as a real marker, and every `linePattern` parses.

**#7 — the review's own suggestion was wrong, and tracing disproved it.** The report flagged `generatePage`'s `slideCount = 0` reset as dead code ("ids are assigned at construction"). But on the HTTP path `generatePage` runs per request, and `verticalSlides` children are *reconstructed at render time*, each drawing its id from that shared counter — so the reset keeps per-slide iframe filenames (`slide-<id>-<n>`) stable across renders. Deleting it would break the HTTP iframe cache. This PR documents *why* the line must stay and adds an idempotency regression test. The broader concurrency hardening (rendering mutates shared state; not thread-safe under concurrent requests) is a deliberate follow-up — a real fix re-times slide-id assignment and would churn every id/filename, so it doesn't belong in a quick-wins batch.

**Docs not regenerated.** When `/docs` is next regenerated, the gtag loader `src` in 8 files will switch to the consumer's id (#1) and letsPlot iframes to `4.10.1` (#6). That's the publish step and is intentionally out of scope here.

## Test coverage

`IncludeTest` 7/7 · `PresentationTest` 22/22 (+5) · `UtilsTest` 20/20 (+2) · `ConfigsTest` 12/12 (+1) · `LetsPlotTest` 6/6 (+1) — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
